### PR TITLE
Add GameTester script with reset ability

### DIFF
--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameTester : MonoBehaviour
+{
+    [Header("References")]
+    public BallLauncher ballLauncher;
+    public WheelSpinner wheelSpinner;
+    public BetManager betManager;
+    public BetEvaluator betEvaluator;
+
+    private List<(Transform tf, Vector3 pos, Quaternion rot)> chipStarts = new();
+    private Vector3 ballStartPos;
+    private Quaternion ballStartRot;
+
+    private void Awake()
+    {
+        foreach (var chip in FindObjectsOfType<BettingChipDragger>())
+        {
+            chipStarts.Add((chip.transform, chip.transform.position, chip.transform.rotation));
+        }
+
+        if (ballLauncher != null)
+        {
+            ballStartPos = ballLauncher.transform.position;
+            ballStartRot = ballLauncher.transform.rotation;
+        }
+    }
+
+    [ContextMenu("Launch Ball")]
+    public void LaunchBall()
+    {
+        if (ballLauncher != null)
+        {
+            ballLauncher.launchNow = true;
+        }
+    }
+
+    [ContextMenu("Spin Wheel")]
+    public void SpinWheel()
+    {
+        wheelSpinner?.StartSpin();
+    }
+
+    [ContextMenu("Reset Game")]
+    public void ResetGame()
+    {
+        if (ballLauncher != null)
+        {
+            ballLauncher.ResetLaunch();
+            ballLauncher.transform.position = ballStartPos;
+            ballLauncher.transform.rotation = ballStartRot;
+        }
+
+        if (wheelSpinner != null)
+        {
+            wheelSpinner.ResetSpin();
+        }
+
+        foreach (var info in chipStarts)
+        {
+            if (info.tf != null)
+            {
+                info.tf.position = info.pos;
+                info.tf.rotation = info.rot;
+            }
+        }
+
+        betManager?.ClearAllBets();
+        betEvaluator?.placedChips.Clear();
+    }
+}

--- a/Assets/Scripts/GameTester.cs.meta
+++ b/Assets/Scripts/GameTester.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a46211e72b34840b2c32c10b986b890

--- a/Assets/Scripts/WheelSpinner.cs
+++ b/Assets/Scripts/WheelSpinner.cs
@@ -12,10 +12,12 @@ public class WheelSpinner : MonoBehaviour
 
     private float currentSpinSpeed = 0f;
     private bool isSpinning = false;
+    private Quaternion initialRotation;
 
     private void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
+        initialRotation = transform.rotation;
     }
 
     public bool IsSpinning()
@@ -49,5 +51,13 @@ public class WheelSpinner : MonoBehaviour
     {
         currentSpinSpeed = initialSpinSpeed;
         isSpinning = true;
+    }
+
+    public void ResetSpin()
+    {
+        isSpinning = false;
+        currentSpinSpeed = 0f;
+        rb.angularVelocity = 0f;
+        transform.rotation = initialRotation;
     }
 }


### PR DESCRIPTION
## Summary
- add a new `GameTester` utility for launching/spinning and for resetting the playfield
- extend `WheelSpinner` with a `ResetSpin()` method and store its starting rotation

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b207ff90c8321ab34eeab9537d111