### PR TITLE
Handle exclusive roulette bet zones

### DIFF
--- a/Assets/Scripts/BetEvaluator.cs
+++ b/Assets/Scripts/BetEvaluator.cs
@@ -50,6 +50,24 @@ public class BetEvaluator : MonoBehaviour
             if (chipCollider == null) continue;
 
             Collider2D[] hits = Physics2D.OverlapCircleAll(chipCollider.bounds.center, 0.1f);
+
+            int exclusiveCount = 0;
+            foreach (var hit in hits)
+            {
+                if (!hit.CompareTag("BetZone")) continue;
+                BetZone zone = hit.GetComponent<BetZone>();
+                if (zone != null && !zone.allowOverlap)
+                {
+                    exclusiveCount++;
+                }
+            }
+
+            if (exclusiveCount > 1)
+            {
+                Debug.LogWarning($"⚠️ Chip {chip.name} overlapped multiple exclusive zones. Ignoring bet.");
+                continue;
+            }
+
             bool isWinning = false;
 
             foreach (var hit in hits)

--- a/Assets/Scripts/BetZone.cs
+++ b/Assets/Scripts/BetZone.cs
@@ -38,4 +38,8 @@ public class BetZone : MonoBehaviour
     [Header("Grouped Betting")]
     [Tooltip("Grouped bet type, like Red, Black, Even, Odd, etc.")]
     public BetGroupType groupType = BetGroupType.None;
+
+    [Header("Overlap Rules")]
+    [Tooltip("If false, chips may not overlap this zone with other exclusive zones.")]
+    public bool allowOverlap = true;
 }


### PR DESCRIPTION
## Summary
- add `allowOverlap` flag to `BetZone`
- skip evaluation if a chip overlaps multiple exclusive zones

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686b2ee5fad083218da4c66c289a04d7