### PR TITLE
Add chip bag spawner and player currency

### DIFF
--- a/Assets/Scripts/BetChip.cs
+++ b/Assets/Scripts/BetChip.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 
 public class BetChip : MonoBehaviour
 {
+    [Header("Chip Value")]
+    [Tooltip("Monetary value of this chip")]
+    public int chipValue = 1;
     [HideInInspector]
     public List<BetZone> betZones = new List<BetZone>();
 

--- a/Assets/Scripts/BettingChipDragger.cs
+++ b/Assets/Scripts/BettingChipDragger.cs
@@ -13,6 +13,8 @@ public class BettingChipDragger : MonoBehaviour
 
     private Camera mainCamera;
     private Collider2D selfCollider;
+    [Tooltip("Collider of the chip bag this chip can be returned to")]
+    public Collider2D bagCollider;
 
     private void Awake()
     {
@@ -60,6 +62,26 @@ public class BettingChipDragger : MonoBehaviour
                 Debug.Log($"    [{count}] {hit.gameObject.name} (Tag: {hit.gameObject.tag}, Layer: {LayerMask.LayerToName(hit.gameObject.layer)})");
             }
         }
+
+        // Check if the chip should return to the bag
+        TryReturnToBag();
+    }
+
+    private bool TryReturnToBag()
+    {
+        if (bagCollider == null)
+            return false;
+
+        if (selfCollider != null && selfCollider.bounds.Intersects(bagCollider.bounds))
+        {
+            if (TryGetComponent(out BetChip betChip))
+            {
+                PlayerCurrency.Instance?.AddCurrency(betChip.chipValue);
+            }
+            Destroy(gameObject);
+            return true;
+        }
+        return false;
     }
 
     void OnMouseDown()

--- a/Assets/Scripts/BettingChipDragger.cs
+++ b/Assets/Scripts/BettingChipDragger.cs
@@ -21,15 +21,14 @@ public class BettingChipDragger : MonoBehaviour
         selfCollider = GetComponent<Collider2D>();
     }
 
-    void OnMouseDown()
+    public void BeginDrag()
     {
-        Debug.Log($"🖱️ Clicked on chip: {gameObject.name}");
         isDragging = true;
         offset = transform.position - GetMouseWorldPosition();
         transform.localScale = originalScale * heldScaleMultiplier;
     }
 
-    void OnMouseDrag()
+    public void DragUpdate()
     {
         if (isDragging)
         {
@@ -37,7 +36,7 @@ public class BettingChipDragger : MonoBehaviour
         }
     }
 
-    void OnMouseUp()
+    public void EndDrag()
     {
         isDragging = false;
         transform.localScale = originalScale;
@@ -61,6 +60,22 @@ public class BettingChipDragger : MonoBehaviour
                 Debug.Log($"    [{count}] {hit.gameObject.name} (Tag: {hit.gameObject.tag}, Layer: {LayerMask.LayerToName(hit.gameObject.layer)})");
             }
         }
+    }
+
+    void OnMouseDown()
+    {
+        Debug.Log($"🖱️ Clicked on chip: {gameObject.name}");
+        BeginDrag();
+    }
+
+    void OnMouseDrag()
+    {
+        DragUpdate();
+    }
+
+    void OnMouseUp()
+    {
+        EndDrag();
     }
 
     private Vector3 GetMouseWorldPosition()

--- a/Assets/Scripts/ChipBag.cs
+++ b/Assets/Scripts/ChipBag.cs
@@ -10,6 +10,12 @@ public class ChipBag : MonoBehaviour
 
     private BettingChipDragger currentDragger;
     private GameObject currentChip;
+    private Collider2D bagCollider;
+
+    private void Awake()
+    {
+        bagCollider = GetComponent<Collider2D>();
+    }
 
     private void OnMouseDown()
     {
@@ -53,6 +59,24 @@ public class ChipBag : MonoBehaviour
         if (currentDragger != null)
         {
             currentDragger.EndDrag();
+
+            bool returned = false;
+            if (currentChip != null && bagCollider != null)
+            {
+                Collider2D chipCol = currentChip.GetComponent<Collider2D>();
+                if (chipCol != null && chipCol.bounds.Intersects(bagCollider.bounds))
+                {
+                    PlayerCurrency.Instance?.AddCurrency(chipValue);
+                    Destroy(currentChip);
+                    returned = true;
+                }
+            }
+
+            if (!returned)
+            {
+                // allow chip to remain in scene
+            }
+
             currentDragger = null;
             currentChip = null;
         }

--- a/Assets/Scripts/ChipBag.cs
+++ b/Assets/Scripts/ChipBag.cs
@@ -43,6 +43,7 @@ public class ChipBag : MonoBehaviour
         if (currentDragger == null)
             currentDragger = currentChip.AddComponent<BettingChipDragger>();
 
+        currentDragger.bagCollider = bagCollider;
         currentDragger.BeginDrag();
     }
 
@@ -59,23 +60,6 @@ public class ChipBag : MonoBehaviour
         if (currentDragger != null)
         {
             currentDragger.EndDrag();
-
-            bool returned = false;
-            if (currentChip != null && bagCollider != null)
-            {
-                Collider2D chipCol = currentChip.GetComponent<Collider2D>();
-                if (chipCol != null && chipCol.bounds.Intersects(bagCollider.bounds))
-                {
-                    PlayerCurrency.Instance?.AddCurrency(chipValue);
-                    Destroy(currentChip);
-                    returned = true;
-                }
-            }
-
-            if (!returned)
-            {
-                // allow chip to remain in scene
-            }
 
             currentDragger = null;
             currentChip = null;

--- a/Assets/Scripts/ChipBag.cs
+++ b/Assets/Scripts/ChipBag.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Collider2D))]
+public class ChipBag : MonoBehaviour
+{
+    [Header("Chip Settings")]
+    public GameObject chipPrefab;
+    public int chipValue = 1;
+    public Transform chipParent;
+
+    private BettingChipDragger currentDragger;
+    private GameObject currentChip;
+
+    private void OnMouseDown()
+    {
+        if (currentChip != null) return;
+
+        if (PlayerCurrency.Instance != null && !PlayerCurrency.Instance.TrySpend(chipValue))
+        {
+            Debug.Log("Not enough currency to take a chip.");
+            return;
+        }
+
+        currentChip = Instantiate(chipPrefab, transform.position, Quaternion.identity, chipParent);
+
+        if (currentChip.TryGetComponent(out BetChip betChip))
+        {
+            betChip.chipValue = chipValue;
+        }
+        else
+        {
+            betChip = currentChip.AddComponent<BetChip>();
+            betChip.chipValue = chipValue;
+        }
+
+        currentDragger = currentChip.GetComponent<BettingChipDragger>();
+        if (currentDragger == null)
+            currentDragger = currentChip.AddComponent<BettingChipDragger>();
+
+        currentDragger.BeginDrag();
+    }
+
+    private void OnMouseDrag()
+    {
+        if (currentDragger != null)
+        {
+            currentDragger.DragUpdate();
+        }
+    }
+
+    private void OnMouseUp()
+    {
+        if (currentDragger != null)
+        {
+            currentDragger.EndDrag();
+            currentDragger = null;
+            currentChip = null;
+        }
+    }
+}

--- a/Assets/Scripts/PlayerCurrency.cs
+++ b/Assets/Scripts/PlayerCurrency.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using TMPro;
+
+public class PlayerCurrency : MonoBehaviour
+{
+    public static PlayerCurrency Instance { get; private set; }
+
+    [Header("Starting Amount")]
+    public int startingCurrency = 500;
+    public TMP_Text currencyText;
+
+    public int CurrentCurrency { get; private set; }
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        CurrentCurrency = startingCurrency;
+        UpdateUI();
+    }
+
+    public bool TrySpend(int amount)
+    {
+        if (CurrentCurrency < amount)
+            return false;
+
+        CurrentCurrency -= amount;
+        UpdateUI();
+        return true;
+    }
+
+    public void AddCurrency(int amount)
+    {
+        CurrentCurrency += amount;
+        UpdateUI();
+    }
+
+    private void UpdateUI()
+    {
+        if (currencyText != null)
+        {
+            currencyText.text = $"Currency: {CurrentCurrency}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support chip values with new field in `BetChip`
- allow external dragging for chips with public methods in `BettingChipDragger`
- add `PlayerCurrency` singleton to track and display player funds
- implement `ChipBag` for spawning chips from a bag prefab

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687380e2c0c88321ba0adaff8579d2a2