### PR TITLE
Expose spin speed from WheelSpinner

### DIFF
--- a/Assets/Scripts/WheelSpinner.cs
+++ b/Assets/Scripts/WheelSpinner.cs
@@ -22,7 +22,18 @@ public class WheelSpinner : MonoBehaviour
 
     public bool IsSpinning()
     {
-        return Mathf.Abs(rb.angularVelocity) > spinThreshold;
+        // Check the internally tracked spin speed rather than the rigidbody's
+        // angular velocity since the wheel is rotated manually.
+        return Mathf.Abs(currentSpinSpeed) > spinThreshold;
+    }
+
+    /// <summary>
+    /// Current angular speed of the wheel in degrees per second.
+    /// Useful for UI prompts or game rules based on wheel movement.
+    /// </summary>
+    public float GetCurrentSpinSpeed()
+    {
+        return currentSpinSpeed;
     }
 
     void Start()


### PR DESCRIPTION
## Summary
- expose current spin speed via method GetCurrentSpinSpeed
- make `IsSpinning` rely on the internal spin speed instead of a rigidbody value that stays zero

This helps other scripts (like UI prompts) check the wheel's rotation speed to know when to reveal results or block further bets.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68747830043083219f8ef3c72864a78e