### PR TITLE
Add bet cutoff manager to lock betting

### DIFF
--- a/Assets/Scripts/BetCutoffManager.cs
+++ b/Assets/Scripts/BetCutoffManager.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+/// <summary>
+/// Locks chip interaction once the wheel slows below a configured speed.
+/// Attach to an object like the GameManager.
+/// </summary>
+public class BetCutoffManager : MonoBehaviour
+{
+    [Header("References")]
+    [Tooltip("Wheel spinner used to determine current speed")] public WheelSpinner wheelSpinner;
+    [Tooltip("UI element shown when bets are locked")] public GameObject noMoreBetsUI;
+
+    [Header("Cutoff Settings")]
+    [Tooltip("When the wheel speed goes below this value, betting is locked")]
+    public float cutoffSpeed = 200f;
+
+    private bool betsLocked = false;
+
+    private void Start()
+    {
+        if (noMoreBetsUI != null)
+            noMoreBetsUI.SetActive(false);
+    }
+
+    private void Update()
+    {
+        if (betsLocked || wheelSpinner == null)
+            return;
+
+        if (Mathf.Abs(wheelSpinner.GetCurrentSpinSpeed()) <= cutoffSpeed)
+        {
+            LockBets();
+        }
+    }
+
+    /// <summary>
+    /// Locks all chip and bag interactions and shows the "no more bets" prompt.
+    /// </summary>
+    public void LockBets()
+    {
+        betsLocked = true;
+        ChipBag.betsLocked = true;
+        BettingChipDragger.betsLocked = true;
+
+        foreach (var dragger in FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None))
+        {
+            dragger.ForceEndDrag();
+        }
+
+        if (noMoreBetsUI != null)
+            noMoreBetsUI.SetActive(true);
+    }
+
+    /// <summary>
+    /// Unlocks betting so chips can be moved again.
+    /// </summary>
+    public void UnlockBets()
+    {
+        betsLocked = false;
+        ChipBag.betsLocked = false;
+        BettingChipDragger.betsLocked = false;
+
+        if (noMoreBetsUI != null)
+            noMoreBetsUI.SetActive(false);
+    }
+}

--- a/Assets/Scripts/BettingChipDragger.cs
+++ b/Assets/Scripts/BettingChipDragger.cs
@@ -7,6 +7,11 @@ public class BettingChipDragger : MonoBehaviour
     [Header("Drag Settings")]
     public float heldScaleMultiplier = 1.2f;
 
+    /// <summary>
+    /// Global flag used to lock chip movement when bets are closed.
+    /// </summary>
+    public static bool betsLocked = false;
+
     private bool isDragging = false;
     private Vector3 originalScale;
     private Vector3 offset;
@@ -25,6 +30,8 @@ public class BettingChipDragger : MonoBehaviour
 
     public void BeginDrag()
     {
+        if (betsLocked)
+            return;
         isDragging = true;
         offset = transform.position - GetMouseWorldPosition();
         transform.localScale = originalScale * heldScaleMultiplier;
@@ -32,6 +39,12 @@ public class BettingChipDragger : MonoBehaviour
 
     public void DragUpdate()
     {
+        if (betsLocked && isDragging)
+        {
+            EndDrag();
+            return;
+        }
+
         if (isDragging)
         {
             transform.position = GetMouseWorldPosition() + offset;
@@ -67,6 +80,15 @@ public class BettingChipDragger : MonoBehaviour
         TryReturnToBag();
     }
 
+    /// <summary>
+    /// Ends dragging if currently being dragged. Used when bets are locked.
+    /// </summary>
+    public void ForceEndDrag()
+    {
+        if (isDragging)
+            EndDrag();
+    }
+
     private bool TryReturnToBag()
     {
         if (bagCollider == null)
@@ -86,6 +108,9 @@ public class BettingChipDragger : MonoBehaviour
 
     void OnMouseDown()
     {
+        if (betsLocked)
+            return;
+
         Debug.Log($"🖱️ Clicked on chip: {gameObject.name}");
         BeginDrag();
     }

--- a/Assets/Scripts/ChipBag.cs
+++ b/Assets/Scripts/ChipBag.cs
@@ -8,6 +8,11 @@ public class ChipBag : MonoBehaviour
     public int chipValue = 1;
     public Transform chipParent;
 
+    /// <summary>
+    /// Global flag to lock chip bag interaction when bets are closed.
+    /// </summary>
+    public static bool betsLocked = false;
+
     private BettingChipDragger currentDragger;
     private GameObject currentChip;
     private Collider2D bagCollider;
@@ -19,6 +24,9 @@ public class ChipBag : MonoBehaviour
 
     private void OnMouseDown()
     {
+        if (betsLocked)
+            return;
+
         if (currentChip != null) return;
 
         if (PlayerCurrency.Instance != null && !PlayerCurrency.Instance.TrySpend(chipValue))
@@ -49,6 +57,7 @@ public class ChipBag : MonoBehaviour
 
     private void OnMouseDrag()
     {
+        if (betsLocked) return;
         if (currentDragger != null)
         {
             currentDragger.DragUpdate();


### PR DESCRIPTION
## Summary
- add `BetCutoffManager` to disable chip interaction once the wheel slows
- allow `ChipBag` and `BettingChipDragger` to respect bet lock

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874bac99b208321bdeb993b10f23c51