### PR TITLE
Add winning slot display system

### DIFF
--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -9,6 +9,7 @@ public class GameTester : MonoBehaviour
     public BetManager betManager;
     public BetEvaluator betEvaluator;
     public BetCutoffManager betCutoffManager;
+    public WinningSlotDisplay slotDisplay;
 
     [Header("Dynamic Launch Settings")]
     [Tooltip("Random range added to the wheel spin speed (\u00b1 value).")]
@@ -122,8 +123,10 @@ public class GameTester : MonoBehaviour
 
         if (betCutoffManager != null)
         {
-            betCutoffManager.UnlockBets(); 
+            betCutoffManager.UnlockBets();
         }
+
+        slotDisplay?.ResetDisplay();
     }
 
     private void Update()

--- a/Assets/Scripts/RouletteBall.cs
+++ b/Assets/Scripts/RouletteBall.cs
@@ -27,6 +27,9 @@ public class RouletteBall : MonoBehaviour
     private GameObject lockedSlot = null;
     private Rigidbody2D rb;
 
+    [Header("Result Display")]
+    [Tooltip("Optional display for showing the winning number")] public WinningSlotDisplay slotDisplay;
+
     private Transform followAnchor = null;
 
     private void Awake()
@@ -157,6 +160,11 @@ public class RouletteBall : MonoBehaviour
             {
                 Debug.LogWarning("⚠️ No BetEvaluator found in the scene.");
             }
+
+            if (slotDisplay != null)
+            {
+                slotDisplay.ShowResult(slot);
+            }
         }
     }
 
@@ -174,6 +182,9 @@ public class RouletteBall : MonoBehaviour
 
         transform.SetParent(null, true);
         transform.localScale = initialScale;
+
+        if (slotDisplay != null)
+            slotDisplay.ResetDisplay();
     }
 
     public GameObject GetWinningSlot()

--- a/Assets/Scripts/WinningSlotDisplay.cs
+++ b/Assets/Scripts/WinningSlotDisplay.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using TMPro;
+using DG.Tweening;
+using System.Collections;
+
+public class WinningSlotDisplay : MonoBehaviour
+{
+    [Header("UI")]
+    [Tooltip("Text element used to show the winning number")] public TMP_Text resultText;
+
+    [Header("Dolly Movement")]
+    [Tooltip("Transform moved to highlight the winning bet")] public Transform dolly;
+    [Tooltip("Where the dolly rests when idle")] public Transform dollyHome;
+    public float dollyMoveDuration = 1f;
+
+    [Header("Effects")]
+    [Tooltip("Prefab spawned at the winning bet location")] public GameObject flashPrefab;
+    [Tooltip("Transforms representing bet positions indexed by number")] public Transform[] tablePositions;
+
+    private GameObject currentFlash;
+    private Coroutine routine;
+
+    private void Awake()
+    {
+        if (resultText != null)
+            resultText.gameObject.SetActive(false);
+    }
+
+    public void ResetDisplay()
+    {
+        if (routine != null)
+        {
+            StopCoroutine(routine);
+            routine = null;
+        }
+
+        if (currentFlash != null)
+        {
+            Destroy(currentFlash);
+            currentFlash = null;
+        }
+
+        if (resultText != null)
+            resultText.gameObject.SetActive(false);
+
+        if (dolly != null && dollyHome != null)
+            dolly.position = dollyHome.position;
+    }
+
+    public void ShowResult(RouletteSlot slot)
+    {
+        if (slot == null) return;
+        if (routine != null)
+            StopCoroutine(routine);
+        routine = StartCoroutine(DisplayRoutine(slot));
+    }
+
+    private IEnumerator DisplayRoutine(RouletteSlot slot)
+    {
+        Transform target = null;
+        if (tablePositions != null && slot.number >= 0 && slot.number < tablePositions.Length)
+            target = tablePositions[slot.number];
+
+        if (target != null && dolly != null)
+            dolly.DOMove(target.position, dollyMoveDuration);
+
+        if (flashPrefab != null && target != null)
+            currentFlash = Instantiate(flashPrefab, target.position, Quaternion.identity);
+
+        yield return new WaitForSeconds(dollyMoveDuration);
+
+        if (resultText != null)
+        {
+            resultText.text = $"Result: {slot.number}";
+            resultText.gameObject.SetActive(true);
+        }
+        routine = null;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WinningSlotDisplay` to animate a dolly and show the result text
- integrate display calls into `RouletteBall`
- hook the new display into `GameTester` reset flow

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877881c07d08321b152d3d6d04fc903