### PR TITLE
Add auto reset feature after bet evaluation

### DIFF
--- a/Assets/Scripts/BetEvaluator.cs
+++ b/Assets/Scripts/BetEvaluator.cs
@@ -7,6 +7,8 @@ public class BetEvaluator : MonoBehaviour
 {
     [Header("References")]
     public RouletteBall rouletteBall;
+    [Tooltip("Optional game manager for automatic resets after evaluation")]
+    public GameTester gameManager;
 
     [Header("Chips")]
     public List<GameObject> placedChips = new List<GameObject>();
@@ -212,6 +214,10 @@ public class BetEvaluator : MonoBehaviour
         }
 
         placedChips.Clear();
+
+        if (gameManager == null)
+            gameManager = FindAnyObjectByType<GameTester>();
+        gameManager?.StartAutoReset();
     }
 
     private void RewardPlayer(GameObject chip, int amount)

--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -24,6 +24,10 @@ public class GameTester : MonoBehaviour
     [Tooltip("Possible spawn positions for the ball.")]
     public Transform[] launchPositions;
 
+    [Header("Auto Reset")]
+    [Tooltip("Seconds to wait after bet evaluation before resetting the game")]
+    public float autoResetDelay = 3f;
+
     private float baseSpinSpeed;
     private float baseLaunchForce;
 
@@ -93,7 +97,7 @@ public class GameTester : MonoBehaviour
     }
 
     [ContextMenu("Reset Game")]
-    public void ResetGame()
+    public void ResetGame(bool resetWheel = true)
     {
         if (ballLauncher != null)
         {
@@ -103,7 +107,7 @@ public class GameTester : MonoBehaviour
             ballLauncher.launchForce = baseLaunchForce;
         }
 
-        if (wheelSpinner != null)
+        if (resetWheel && wheelSpinner != null)
         {
             wheelSpinner.ResetSpin();
             wheelSpinner.initialSpinSpeed = baseSpinSpeed;
@@ -127,6 +131,18 @@ public class GameTester : MonoBehaviour
         }
 
         slotDisplay?.ResetDisplay();
+    }
+
+    public void StartAutoReset()
+    {
+        StopCoroutine(AutoResetRoutine());
+        StartCoroutine(AutoResetRoutine());
+    }
+
+    private IEnumerator AutoResetRoutine()
+    {
+        yield return new WaitForSeconds(autoResetDelay);
+        ResetGame(false);
     }
 
     private void Update()


### PR DESCRIPTION
## Summary
- enable optional auto reset delay in `GameTester`
- trigger reset without stopping the wheel when `BetEvaluator` finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687af463b9908321a95b9248ee42f80d