### PR TITLE
Add TableReset routine for chip collection

### DIFF
--- a/Assets/Scripts/BetEvaluator.cs
+++ b/Assets/Scripts/BetEvaluator.cs
@@ -7,6 +7,13 @@ public class BetEvaluator : MonoBehaviour
 {
     [Header("References")]
     public RouletteBall rouletteBall;
+    [Tooltip("Game tester used to reset the table")] public GameTester gameTester;
+
+    [Header("Table Reset")]
+    [Tooltip("Delay before resetting the game once chips are collected")]
+    public float tableResetDelay = 1f;
+    [Tooltip("Skip resetting the wheel when resetting from this script")]
+    public bool skipWheelReset = true;
 
     [Header("Chips")]
     public List<GameObject> placedChips = new List<GameObject>();
@@ -212,6 +219,23 @@ public class BetEvaluator : MonoBehaviour
         }
 
         placedChips.Clear();
+
+        TableReset();
+    }
+
+    private void TableReset()
+    {
+        if (gameTester == null)
+            return;
+
+        StartCoroutine(TableResetRoutine());
+    }
+
+    private IEnumerator TableResetRoutine()
+    {
+        yield return new WaitForSeconds(tableResetDelay);
+
+        gameTester.ResetGame(!skipWheelReset);
     }
 
     private void RewardPlayer(GameObject chip, int amount)

--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -92,8 +92,14 @@ public class GameTester : MonoBehaviour
         }
     }
 
+
     [ContextMenu("Reset Game")]
     public void ResetGame()
+    {
+        ResetGame(true);
+    }
+
+    public void ResetGame(bool resetWheel)
     {
         if (ballLauncher != null)
         {
@@ -103,7 +109,7 @@ public class GameTester : MonoBehaviour
             ballLauncher.launchForce = baseLaunchForce;
         }
 
-        if (wheelSpinner != null)
+        if (wheelSpinner != null && resetWheel)
         {
             wheelSpinner.ResetSpin();
             wheelSpinner.initialSpinSpeed = baseSpinSpeed;


### PR DESCRIPTION
## Summary
- support optional wheel spinner reset in `GameTester.ResetGame`
- add configurable table reset logic to `BetEvaluator`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b12f80e1483218994639c65f5aa1b