### PR TITLE
Fix chip cleanup to use snapshot

### DIFF
--- a/Assets/Scripts/BetCutoffManager.cs
+++ b/Assets/Scripts/BetCutoffManager.cs
@@ -43,7 +43,8 @@ public class BetCutoffManager : MonoBehaviour
         ChipBag.betsLocked = true;
         BettingChipDragger.betsLocked = true;
 
-        foreach (var dragger in FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None))
+        var chips = FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None);
+        foreach (var dragger in chips)
         {
             dragger.ForceEndDrag();
         }

--- a/Assets/Scripts/BetEvaluator.cs
+++ b/Assets/Scripts/BetEvaluator.cs
@@ -268,7 +268,8 @@ public class BetEvaluator : MonoBehaviour
     public void GatherChipsFromScene()
     {
         placedChips.Clear();
-        foreach (var dragger in FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None))
+        var chips = FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None);
+        foreach (var dragger in chips)
         {
             placedChips.Add(dragger.gameObject);
         }

--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -123,14 +123,12 @@ public class GameTester : MonoBehaviour
             wheelSpinner.initialSpinSpeed = baseSpinSpeed;
         }
 
-        // Destroy all chips in the scene
-        List<BettingChipDragger> chips = new List<BettingChipDragger>(FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None));
+        // Destroy all chips in the scene using a snapshot to avoid collection
+        // modification issues when many chips are present
+        var chips = FindObjectsByType<BettingChipDragger>(FindObjectsSortMode.None);
         foreach (var chip in chips)
         {
-            if (chip != null)
-            {
-                Destroy(chip.gameObject);
-            }
+            Destroy(chip.gameObject);
         }
 
         betManager?.ClearAllBets();


### PR DESCRIPTION
## Summary
- fix ResetGame to use a stable snapshot before destroying chips
- update other calls to `FindObjectsByType` to capture the array first

## Testing
- `grep -n "FindObjectsByType" -R Assets/Scripts | head`

------
https://chatgpt.com/codex/tasks/task_e_687b1c70bda48321ac07b63e2933dcd4