### PR TITLE
Fix bets remaining locked after spin-and-launch

### DIFF
--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -117,9 +117,19 @@ public class GameTester : MonoBehaviour
             ballLauncher.launchForce = baseLaunchForce;
         }
 
-        if (wheelSpinner != null && resetWheel)
+        if (wheelSpinner != null)
         {
-            wheelSpinner.ResetSpin();
+            if (resetWheel)
+            {
+                wheelSpinner.ResetSpin();
+            }
+            else
+            {
+                // Stop the wheel without resetting its rotation so the next round
+                // begins from the same orientation.
+                wheelSpinner.StopSpin();
+            }
+
             wheelSpinner.initialSpinSpeed = baseSpinSpeed;
         }
 

--- a/Assets/Scripts/WheelSpinner.cs
+++ b/Assets/Scripts/WheelSpinner.cs
@@ -70,4 +70,15 @@ public class WheelSpinner : MonoBehaviour
         rb.angularVelocity = 0f;
         transform.rotation = initialRotation;
     }
+
+    /// <summary>
+    /// Stops the wheel from spinning without changing its current rotation.
+    /// Useful when the wheel orientation should persist between rounds.
+    /// </summary>
+    public void StopSpin()
+    {
+        isSpinning = false;
+        currentSpinSpeed = 0f;
+        rb.angularVelocity = 0f;
+    }
 }


### PR DESCRIPTION
## Summary
- add `WheelSpinner.StopSpin` so the wheel can stop without resetting rotation
- stop the wheel when resetting the game without a wheel reset so bets unlock properly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c3ba386448321a27b83b3d77d66d9