### PR TITLE
Avoid stopping wheel when unlocking bets

### DIFF
--- a/Assets/Scripts/BetCutoffManager.cs
+++ b/Assets/Scripts/BetCutoffManager.cs
@@ -15,6 +15,9 @@ public class BetCutoffManager : MonoBehaviour
     public float cutoffSpeed = 200f;
 
     private bool betsLocked = false;
+    // Indicates whether the cutoff was triggered this round so it isn't
+    // continually checked after locking bets
+    private bool cutoffTriggered = false;
 
     private void Start()
     {
@@ -24,7 +27,7 @@ public class BetCutoffManager : MonoBehaviour
 
     private void Update()
     {
-        if (betsLocked || wheelSpinner == null)
+        if (betsLocked || wheelSpinner == null || cutoffTriggered)
             return;
 
         // Only lock bets if the wheel has started spinning and is now slowing down
@@ -40,6 +43,7 @@ public class BetCutoffManager : MonoBehaviour
     public void LockBets()
     {
         betsLocked = true;
+        cutoffTriggered = true;
         ChipBag.betsLocked = true;
         BettingChipDragger.betsLocked = true;
 
@@ -65,4 +69,13 @@ public class BetCutoffManager : MonoBehaviour
         if (noMoreBetsUI != null)
             noMoreBetsUI.SetActive(false);
     }
+
+    /// <summary>
+    /// Resets the cutoff trigger so bets can be locked again next round.
+    /// </summary>
+    public void ResetCutoff()
+    {
+        cutoffTriggered = false;
+    }
 }
+

--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -117,9 +117,14 @@ public class GameTester : MonoBehaviour
             ballLauncher.launchForce = baseLaunchForce;
         }
 
-        if (wheelSpinner != null && resetWheel)
+        if (wheelSpinner != null)
         {
-            wheelSpinner.ResetSpin();
+            if (resetWheel)
+            {
+                wheelSpinner.ResetSpin();
+            }
+
+            // Always restore the base spin speed for the next round
             wheelSpinner.initialSpinSpeed = baseSpinSpeed;
         }
 
@@ -137,6 +142,7 @@ public class GameTester : MonoBehaviour
         if (betCutoffManager != null)
         {
             betCutoffManager.UnlockBets();
+            betCutoffManager.ResetCutoff();
         }
 
         slotDisplay?.ResetDisplay();
@@ -167,3 +173,4 @@ public class GameTester : MonoBehaviour
         }
     }
 }
+

--- a/Assets/Scripts/WheelSpinner.cs
+++ b/Assets/Scripts/WheelSpinner.cs
@@ -70,4 +70,15 @@ public class WheelSpinner : MonoBehaviour
         rb.angularVelocity = 0f;
         transform.rotation = initialRotation;
     }
+
+    /// <summary>
+    /// Stops the wheel from spinning without changing its current rotation.
+    /// Useful when the wheel orientation should persist between rounds.
+    /// </summary>
+    public void StopSpin()
+    {
+        isSpinning = false;
+        currentSpinSpeed = 0f;
+        rb.angularVelocity = 0f;
+    }
 }


### PR DESCRIPTION
## Summary
- stop re-checking bet cutoff once triggered
- reset the cutoff trigger when resetting the game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c3ba386448321a27b83b3d77d66d9