### PR TITLE
Add bet history tracking

### DIFF
--- a/Assets/Scripts/BetCutoffManager.cs
+++ b/Assets/Scripts/BetCutoffManager.cs
@@ -49,6 +49,9 @@ public class BetCutoffManager : MonoBehaviour
             dragger.ForceEndDrag();
         }
 
+        // capture starting currency for the upcoming spin
+        BetHistorySign.Instance?.StartRound();
+
         if (noMoreBetsUI != null)
             noMoreBetsUI.SetActive(true);
     }

--- a/Assets/Scripts/BetEvaluator.cs
+++ b/Assets/Scripts/BetEvaluator.cs
@@ -33,6 +33,8 @@ public class BetEvaluator : MonoBehaviour
     // Store rewards per chip to process after movement
     private Dictionary<GameObject, int> rewardAmounts = new();
 
+    private RouletteSlot lastWinningSlot;
+
     [ContextMenu("Evaluate Bets")]
     public void EvaluateBets()
     {
@@ -61,6 +63,8 @@ public class BetEvaluator : MonoBehaviour
             Debug.LogWarning("❌ Winning slot has no RouletteSlot component.");
             return;
         }
+
+        lastWinningSlot = slotComponent;
 
         List<GameObject> winningChips = new List<GameObject>();
         List<GameObject> losingChips = new List<GameObject>();
@@ -234,6 +238,12 @@ public class BetEvaluator : MonoBehaviour
     private IEnumerator TableResetRoutine()
     {
         yield return new WaitForSeconds(tableResetDelay);
+
+        if (lastWinningSlot != null)
+        {
+            BetHistorySign.Instance?.EndRound(lastWinningSlot);
+            lastWinningSlot = null;
+        }
 
         gameTester.ResetGame(!skipWheelReset);
     }

--- a/Assets/Scripts/BetHistorySign.cs
+++ b/Assets/Scripts/BetHistorySign.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+
+/// <summary>
+/// Simple helper that records the result of each spin and displays it
+/// in a scrolling history list. Attach this to a UI object and assign a
+/// TMP_Text component for <see cref="historyText"/>. Call
+/// <see cref="StartRound"/> when bets are locked and
+/// <see cref="EndRound"/> once rewards have been paid out.
+/// </summary>
+public class BetHistorySign : MonoBehaviour
+{
+    public static BetHistorySign Instance { get; private set; }
+
+    [Header("UI")]
+    [Tooltip("Text element used to display bet history entries")]
+    public TMP_Text historyText;
+    [Tooltip("Maximum number of entries to keep in history")] public int maxEntries = 10;
+
+    private readonly List<string> entries = new();
+    private int startCurrency = 0;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+    }
+
+    /// <summary>
+    /// Capture the player's currency at the beginning of a round.
+    /// </summary>
+    public void StartRound()
+    {
+        startCurrency = PlayerCurrency.Instance?.CurrentCurrency ?? 0;
+    }
+
+    /// <summary>
+    /// Record the final result of the round.
+    /// </summary>
+    /// <param name="slot">Winning roulette slot.</param>
+    public void EndRound(RouletteSlot slot)
+    {
+        if (slot == null)
+            return;
+
+        int endCurrency = PlayerCurrency.Instance?.CurrentCurrency ?? 0;
+        int delta = endCurrency - startCurrency;
+
+        string color = slot.color switch
+        {
+            RouletteColor.Red => "Red",
+            RouletteColor.Black => "Black",
+            _ => "Green"
+        };
+
+        string entry = $"{slot.number} ({color})  {(delta >= 0 ? "+" : "-")}{Mathf.Abs(delta)}";
+        entries.Insert(0, entry);
+        if (entries.Count > maxEntries)
+            entries.RemoveAt(entries.Count - 1);
+
+        if (historyText != null)
+            historyText.text = string.Join("\n", entries);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `BetHistorySign` for recording round outcomes
- log starting currency in `BetCutoffManager`
- record winning slot and update history in `BetEvaluator`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688190f352ac8321b893a8ad832271f1