### PR TITLE
Add crab movement manager

### DIFF
--- a/Assets/Scripts/BallLauncher.cs
+++ b/Assets/Scripts/BallLauncher.cs
@@ -47,6 +47,8 @@ public class BallLauncher : MonoBehaviour
             cutoffManager.BeginCutoffMonitoring(); // Start watching wheel
         }
 
+        CrabMovementManager.Instance?.OnBallLaunched();
+
         Debug.Log("🚀 Ball launched!");
     }
 

--- a/Assets/Scripts/BetCutoffManager.cs
+++ b/Assets/Scripts/BetCutoffManager.cs
@@ -50,6 +50,8 @@ public class BetCutoffManager : MonoBehaviour
             dragger.ForceEndDrag();
         }
 
+        CrabMovementManager.Instance?.OnNoMoreBets();
+
         // bets are locked; chips can't be moved anymore
 
         if (noMoreBetsUI != null)

--- a/Assets/Scripts/ChipCrabMover.cs
+++ b/Assets/Scripts/ChipCrabMover.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using DG.Tweening;
+
+/// <summary>
+/// Animates a chip as if a crab underneath it moves the chip to a new spot.
+/// Can only trigger before the ball locks into its final slot.
+/// </summary>
+[RequireComponent(typeof(SpriteRenderer))]
+public class ChipCrabMover : MonoBehaviour
+{
+    [Header("Crab Movement")]
+    [Tooltip("Sprite to use when the crab is moving the chip")] public Sprite crabSprite;
+    [Tooltip("Offset applied when moving the chip")] public Vector2 moveOffset = new Vector2(0.5f, 0f);
+    [Tooltip("Duration of the move animation")] public float moveDuration = 1f;
+
+    [Header("Debug")]
+    [Tooltip("Tick to trigger the crab move once")] public bool triggerMove = false;
+
+    private SpriteRenderer spriteRenderer;
+    private Sprite originalSprite;
+
+    private void Awake()
+    {
+        spriteRenderer = GetComponent<SpriteRenderer>();
+        originalSprite = spriteRenderer.sprite;
+    }
+
+    private void Start()
+    {
+        moveOffset = new Vector2(Random.Range(-0.5f, 0.5f), Random.Range(-0.5f, 0.5f));
+    }
+
+    private void Update()
+    {
+        if (triggerMove)
+        {
+            triggerMove = false;
+            MoveWithCrab();
+        }
+    }
+
+    /// <summary>
+    /// Triggers the crab animation if the ball hasn't locked into a slot.
+    /// </summary>
+    [ContextMenu("Move With Crab")]
+    public void MoveWithCrab()
+    {
+        if (RouletteBall.BallLocked)
+            return;
+
+        if (crabSprite != null)
+            spriteRenderer.sprite = crabSprite;
+
+        Vector3 target = transform.position + (Vector3)moveOffset;
+        transform.DOMove(target, moveDuration).OnComplete(() =>
+        {
+            if (originalSprite != null)
+                spriteRenderer.sprite = originalSprite;
+            if (TryGetComponent(out BetChip chip))
+                chip.UpdateBetZones();
+        });
+    }
+}

--- a/Assets/Scripts/ChipCrabMover.cs.meta
+++ b/Assets/Scripts/ChipCrabMover.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5f4fb0f9b9ed49a0bd386479a9ed9007

--- a/Assets/Scripts/CrabMovementManager.cs
+++ b/Assets/Scripts/CrabMovementManager.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+/// <summary>
+/// Controls random chip movements by hidden crabs during a round.
+/// Attach to a GameManager object.
+/// </summary>
+public class CrabMovementManager : MonoBehaviour
+{
+    public static CrabMovementManager Instance { get; private set; }
+
+    [Header("Crab Chances")]
+    [Tooltip("Chance a chip moves when the ball starts spinning")] 
+    [Range(0f,1f)] public float spinStartChance = 0.3f;
+    [Tooltip("Chance a chip moves when bets are locked")] 
+    [Range(0f,1f)] public float noMoreBetsChance = 0.2f;
+
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+    public void OnBallLaunched()
+    {
+        TryTriggerCrab(spinStartChance);
+    }
+
+    public void OnNoMoreBets()
+    {
+        TryTriggerCrab(noMoreBetsChance);
+    }
+
+    private void TryTriggerCrab(float chance)
+    {
+        if (Random.value > chance)
+            return;
+
+        var movers = FindObjectsByType<ChipCrabMover>(FindObjectsSortMode.None);
+        if (movers == null || movers.Length == 0)
+            return;
+
+        var mover = movers[Random.Range(0, movers.Length)];
+        if (mover != null)
+            mover.MoveWithCrab();
+    }
+}

--- a/Assets/Scripts/CrabMovementManager.cs.meta
+++ b/Assets/Scripts/CrabMovementManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 960b02c7-d7a1-45af-8702-5a9dae9b4bb4

--- a/Assets/Scripts/RouletteBall.cs
+++ b/Assets/Scripts/RouletteBall.cs
@@ -4,6 +4,10 @@ using System.Collections.Generic;
 
 public class RouletteBall : MonoBehaviour
 {
+    /// <summary>
+    /// True once the ball has locked into a slot for the current round.
+    /// </summary>
+    public static bool BallLocked { get; private set; } = false;
     [Header("Detection Settings")]
     [Tooltip("Seconds the ball must remain in a slot before locking in.")]
     public float timeToConfirm = 3f;
@@ -221,6 +225,7 @@ public class RouletteBall : MonoBehaviour
             return;
 
         isLocked = true;
+        BallLocked = true;
         PlayRandomClip(slotDropSounds);
         resultSent = true;
         lockedSlot = currentSlot.gameObject;
@@ -282,6 +287,7 @@ public class RouletteBall : MonoBehaviour
         timeInSlot = 0f;
         resultSent = false;
         isLocked = false;
+        BallLocked = false;
         hasStartedMoving = false;
         followAnchor = null;
         if (snapRoutine != null)


### PR DESCRIPTION
## Summary
- randomize chip crab movement offset on spawn
- allow crab move multiple times before the ball locks
- trigger random crab moves when the ball launches or bets lock
- manage crab move chances via `CrabMovementManager`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887f375fa2c83219e0b6285a3bcdadf