### PR TITLE
Add fish disruption event controller and chip trigger

### DIFF
--- a/Assets/Scripts/FishDisruptionChipTrigger.cs
+++ b/Assets/Scripts/FishDisruptionChipTrigger.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+/// <summary>
+/// Attach to a betting chip that should trigger a roll for the fish disruption event
+/// when it comes into play.
+/// </summary>
+public class FishDisruptionChipTrigger : MonoBehaviour
+{
+    [Tooltip("Controller that manages the fish disruption chance.")]
+    public FishDisruptionSpawnerController controller;
+
+    void OnEnable()
+    {
+        if (controller != null)
+        {
+            controller.RollForFishDisruption();
+        }
+    }
+}

--- a/Assets/Scripts/FishDisruptionChipTrigger.cs.meta
+++ b/Assets/Scripts/FishDisruptionChipTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f10805e12db4390a82881011988fe93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FishDisruptionSpawnerController.cs
+++ b/Assets/Scripts/FishDisruptionSpawnerController.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+public class FishDisruptionSpawnerController : MonoBehaviour
+{
+    [Tooltip("Base probability that the fish disruption event triggers.")]
+    [Range(0f, 1f)]
+    public float baseChance = 0.1f;
+
+    [Tooltip("Optional modifier that can adjust the chance in real time.")]
+    public RandomChanceChanger randomChanceChanger;
+
+    [Tooltip("Component responsible for spawning the fish disruption event.")]
+    public MonoBehaviour fishDisruptionSpawner;
+
+    /// <summary>
+    /// Attempts to trigger the fish disruption event using a random roll.
+    /// </summary>
+    public void RollForFishDisruption()
+    {
+        float chance = baseChance;
+        if (randomChanceChanger != null)
+        {
+            chance = randomChanceChanger.ModifyChance(baseChance);
+        }
+
+        if (Random.value <= chance && fishDisruptionSpawner != null)
+        {
+            // Call a Spawn method on the spawner if it exists.
+            fishDisruptionSpawner.SendMessage("Spawn", SendMessageOptions.DontRequireReceiver);
+        }
+    }
+}

--- a/Assets/Scripts/FishDisruptionSpawnerController.cs.meta
+++ b/Assets/Scripts/FishDisruptionSpawnerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01513b6f0ff2487cbfe1dadd14d907b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RandomChanceChanger.cs
+++ b/Assets/Scripts/RandomChanceChanger.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class RandomChanceChanger : MonoBehaviour
+{
+    [Tooltip("Additive modifier applied to the base chance.")]
+    public float chanceModifier = 0f;
+
+    /// <summary>
+    /// Returns the adjusted chance after applying the modifier.
+    /// </summary>
+    public float ModifyChance(float baseChance)
+    {
+        return Mathf.Clamp01(baseChance + chanceModifier);
+    }
+}

--- a/Assets/Scripts/RandomChanceChanger.cs.meta
+++ b/Assets/Scripts/RandomChanceChanger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b13930fb30243adaaad414fbd8955ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Create `FishDisruptionSpawnerController` for rolling and triggering fish disruption events
- Add `RandomChanceChanger` component to adjust probabilities from the inspector
- Introduce `FishDisruptionChipTrigger` so special chips can trigger the controller when played

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fe2437d7c83218598f9659a308a21