### PR TITLE
feat: add developer control activation to GameTester

### DIFF
--- a/Assets/Scripts/GameTester.cs
+++ b/Assets/Scripts/GameTester.cs
@@ -33,6 +33,11 @@ public class GameTester : MonoBehaviour
 
     private bool isResetting = false;
 
+    [Header("Developer Controls")]
+    [Tooltip("Sound played when developer controls are activated.")]
+    public AudioClip devActivateClip;
+    private bool devControlsActive = false;
+
     private void Awake()
     {
         if (ballLauncher != null)
@@ -152,12 +157,21 @@ public class GameTester : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.LeftArrow))
+        if (Input.GetKeyDown(KeyCode.BackQuote))
+        {
+            devControlsActive = !devControlsActive;
+            if (devControlsActive && devActivateClip != null)
+            {
+                AudioSource.PlayClipAtPoint(devActivateClip, transform.position);
+            }
+        }
+
+        if (devControlsActive && Input.GetKeyDown(KeyCode.LeftArrow))
         {
             LaunchBall();
         }
 
-        if (Input.GetKeyDown(KeyCode.UpArrow))
+        if (devControlsActive && Input.GetKeyDown(KeyCode.UpArrow))
         {
             SpinWheel();
         }
@@ -167,7 +181,7 @@ public class GameTester : MonoBehaviour
             SpinAndLaunch();
         }
 
-        if (Input.GetKeyDown(KeyCode.RightArrow))
+        if (devControlsActive && Input.GetKeyDown(KeyCode.RightArrow))
         {
             ResetGame();
         }


### PR DESCRIPTION
## Summary
- add dev control toggle triggered by `~`
- gate arrow key commands behind dev activation and play audio when enabled

## Testing
- `dotnet test` (fails: MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_689926fdc4c08321b4b415931e6ee8a9